### PR TITLE
Remove use of ioutil package

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	yaml "gopkg.in/yaml.v2"
@@ -51,7 +50,7 @@ func main() {
 }
 
 func toJSON(r io.Reader) ([]byte, error) {
-	ybuf, err := ioutil.ReadAll(r)
+	ybuf, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)